### PR TITLE
Updated branch badges for CodeCov.io to point to mainline fork - Fixes #38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Readme.md:
   - Fixed Markdown rule violations.
   - Added missing cmdlets.
+  - Updated branch badges for CodeCov.io to point to mainline
+    fork.
 - Unit Tests:
   - Fixed PS Script Analyzer and added support for reporting on
     warning-level rules. Copied from Microsoft DSC Resource Kit

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 Branch | Build Status | Code Coverage | Protected
 --- | --- | --- | ---
-master | [![Master](https://ci.appveyor.com/api/projects/status/2fc84qwbsidtgvfq/branch/master?svg=true)](https://ci.appveyor.com/project/adamdriscoll/vstsposh/branch/master) | [![codecov](https://codecov.io/gh/PlagueHO/VSTSPosh/branch/master/graph/badge.svg)](https://codecov.io/gh/PlagueHO/VSTSPosh/branch/master) | Yes
-dev | [![Development](https://ci.appveyor.com/api/projects/status/2fc84qwbsidtgvfq/branch/develop?svg=true)](https://ci.appveyor.com/project/adamdriscoll/vstsposh/branch/develop) | [![codecov](https://codecov.io/gh/PlagueHO/VSTSPosh/branch/dev/graph/badge.svg)](https://codecov.io/gh/PlagueHO/VSTSPosh/branch/dev) | No
+master | [![Master](https://ci.appveyor.com/api/projects/status/2fc84qwbsidtgvfq/branch/master?svg=true)](https://ci.appveyor.com/project/adamdriscoll/vstsposh/branch/master) | [![codecov](https://codecov.io/gh/adamdriscoll/VSTSPosh/branch/master/graph/badge.svg)](https://codecov.io/gh/adamdriscoll/VSTSPosh/branch/master) | Yes
+develop | [![Development](https://ci.appveyor.com/api/projects/status/2fc84qwbsidtgvfq/branch/develop?svg=true)](https://ci.appveyor.com/project/adamdriscoll/vstsposh/branch/develop) | [![codecov](https://codecov.io/gh/adamdriscoll/VSTSPosh/branch/develop/graph/badge.svg)](https://codecov.io/gh/adamdriscoll/VSTSPosh/branch/develop) | No
 
 ## Cmdlets
 


### PR DESCRIPTION
This PR changes the branch badges in README.MD to show info for your fork instead of mine.

I've also corrected the name of the "dev" branch to be "develop".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/adamdriscoll/vstsposh/39)
<!-- Reviewable:end -->
