### PR TITLE
Added all Cmdlets to Manifest Generation Script - Fixes #40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@
   - Style consistency cleanup.
   - Added CmdletBinding and other PowerShell best practice changes.
   - Unit tests completed.
+- Added all cmdlets to manifest creation script.
 
 ## 1.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Readme.md:
   - Fixed Markdown rule violations.
   - Added missing cmdlets.
+  - Updated branch badges for CodeCov.io to point to mainline
+    fork.
 - Unit Tests:
   - Fixed PS Script Analyzer and added support for reporting on
     warning-level rules. Copied from Microsoft DSC Resource Kit

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 Branch | Build Status | Code Coverage | Protected
 --- | --- | --- | ---
-master | [![Master](https://ci.appveyor.com/api/projects/status/2fc84qwbsidtgvfq/branch/master?svg=true)](https://ci.appveyor.com/project/adamdriscoll/vstsposh/branch/master) | [![codecov](https://codecov.io/gh/PlagueHO/VSTSPosh/branch/master/graph/badge.svg)](https://codecov.io/gh/PlagueHO/VSTSPosh/branch/master) | Yes
-dev | [![Development](https://ci.appveyor.com/api/projects/status/2fc84qwbsidtgvfq/branch/develop?svg=true)](https://ci.appveyor.com/project/adamdriscoll/vstsposh/branch/develop) | [![codecov](https://codecov.io/gh/PlagueHO/VSTSPosh/branch/dev/graph/badge.svg)](https://codecov.io/gh/PlagueHO/VSTSPosh/branch/dev) | No
+master | [![Master](https://ci.appveyor.com/api/projects/status/2fc84qwbsidtgvfq/branch/master?svg=true)](https://ci.appveyor.com/project/adamdriscoll/vstsposh/branch/master) | [![codecov](https://codecov.io/gh/adamdriscoll/VSTSPosh/branch/master/graph/badge.svg)](https://codecov.io/gh/adamdriscoll/VSTSPosh/branch/master) | Yes
+develop | [![Development](https://ci.appveyor.com/api/projects/status/2fc84qwbsidtgvfq/branch/develop?svg=true)](https://ci.appveyor.com/project/adamdriscoll/vstsposh/branch/develop) | [![codecov](https://codecov.io/gh/adamdriscoll/VSTSPosh/branch/develop/graph/badge.svg)](https://codecov.io/gh/adamdriscoll/VSTSPosh/branch/develop) | No
 
 ## Cmdlets
 

--- a/ci/New-ModuleManifest.ps1
+++ b/ci/New-ModuleManifest.ps1
@@ -1,31 +1,41 @@
 $FunctionsToExport = @(
-'Get-VstsProject',
-'New-VstsProject',
-'Remove-VstsProject',
-'Get-VstsWorkItem',
-'New-VstsWorkItem',
-'Get-VstsWorkItemQuery',
-'Get-VstsCodePolicy',
-'New-VstsCodePolicy',
-'New-VstsGitRepository',
-'Get-VstsGitRepository',
-'New-VstsSession',
-'Get-VstsProcess',
-'Get-VstsBuild',
-'Get-VstsBuildDefinition',
-'ConvertTo-VstsGitRepository')
+    'New-VstsSession',
+    'Get-VstsProject',
+    'New-VstsProject',
+    'Remove-VstsProject',
+    'Wait-VstsProject',
+    'Get-VstsWorkItem',
+    'New-VstsWorkItem',
+    'Get-VstsWorkItemQuery',
+    'Get-VstsCodePolicyConfiguration',
+    'New-VstsCodePolicyConfiguration',
+    'Get-VstsGitRepository',
+    'New-VstsGitRepository',
+    'Remove-VstsGitRepository',
+    'ConvertTo-VstsGitRepository',
+    'New-VstsSession',
+    'Get-VstsProcess',
+    'Get-VstsBuild',
+    'Get-VstsBuildArtifact',
+    'New-VstsBuildDefinition',
+    'Get-VstsBuildDefinition',
+    'Get-VstsBuildQueue',
+    'Get-VstsBuildTag',
+    'Get-VstsRelease',
+    'Get-VstsReleaseDefinition'
+)
 
 $NewModuleManifestParams = @{
-	ModuleVersion = $ENV:APPVEYOR_BUILD_VERSION
-	Path = (Join-Path $PSScriptRoot '.\..\VSTS.psd1')
-	Author = 'Adam Driscoll'
-	Company = 'Adam Driscoll'
-	Description = 'Visual Studio Team Services and Team Foundation Server PowerShell Integration'
-	RootModule = 'VSTS.psm1'
-	FunctionsToExport = $FunctionsToExport
-	ProjectUri = 'https://github.com/adamdriscoll/vstsposh'
-	Tags = @('VSTS', 'TFS', 'VisualStudioTeamServices', 'TeamFoundationServer', 'VSO')
-	RequiredAssemblies = 'System.Web'
+    ModuleVersion      = $ENV:APPVEYOR_BUILD_VERSION
+    Path               = (Join-Path $PSScriptRoot '.\..\VSTS.psd1')
+    Author             = 'Adam Driscoll'
+    Company            = 'Adam Driscoll'
+    Description        = 'Visual Studio Team Services and Team Foundation Server PowerShell Integration'
+    RootModule         = 'VSTS.psm1'
+    FunctionsToExport  = $FunctionsToExport
+    ProjectUri         = 'https://github.com/adamdriscoll/vstsposh'
+    Tags               = @('VSTS', 'TFS', 'VisualStudioTeamServices', 'TeamFoundationServer', 'VSO')
+    RequiredAssemblies = 'System.Web'
 }
 
 New-ModuleManifest @NewModuleManifestParams


### PR DESCRIPTION
This PR adds any missing cmdlets to the Manifest generation code so that they are exposed when published to the PS Gallery.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/adamdriscoll/vstsposh/41)
<!-- Reviewable:end -->
