### PR TITLE
Fix Get-Workitem failing because of unecessary $Project reference

### DIFF
--- a/Tests/WorkItems.tests.ps1
+++ b/Tests/WorkItems.tests.ps1
@@ -41,6 +41,23 @@ Describe 'Work items' -Tags 'Integration' {
             $script:workItem.Fields.'System.Title' | Should Be 'This is a test work item'
             $script:workItem.Fields.'System.Description' | Should Be 'Test'
         }
+
+        It 'Should find a work item' {
+            { $script:createdWorkItem = New-VstsWorkItem `
+                    -Session $session `
+                    -WorkItemType 'Task' `
+                    -Project $projectName `
+                    -PropertyHashtable @{
+                    'System.Title'       = 'This is a work item I want to find'
+                    'System.Description' = 'Test'
+                } `
+                    -Verbose } | Should Not Throw
+            { $script:foundWorkItem = Get-VstsWorkItem `
+                    -Session $session `
+                    -Id $script:createdWorkItem.Id `
+                    -Verbose } | Should Not Throw
+            $script:foundWorkItem.Fields.'System.Title' | Should Be 'This is a work item I want to find'
+            }
     }
 
     AfterAll {

--- a/lib/Workitems.ps1
+++ b/lib/Workitems.ps1
@@ -89,7 +89,6 @@ function Get-VstsWorkItem
 
     $result = Invoke-VstsEndpoint `
         -Session $Session `
-        -Project $Project `
         -Path $path `
         @additionalInvokeParameters
 


### PR DESCRIPTION
Hi,
I tried to use your project to access work items with Get-Workitem, but it failed because this function as no Project parameter while trying to pass one to Invoke-VstsEndpoint. So $Project is null, and the function call fails as it expect a non-null project if one is given.
The project name is not necessary to access its work items, only the work items ids are needed.
Thanks