### PR TITLE
Provide the ability to expand Environments and Artefacts on Get-VstsReleaseDefinition

### DIFF
--- a/lib/Releases.ps1
+++ b/lib/Releases.ps1
@@ -41,7 +41,12 @@ function Get-VstsReleaseDefinition
         [String] $Project,
 
         [Parameter()]
-        [Int32] $DefinitionId
+        [Int32] $DefinitionId,
+
+        [Parameter()]
+        [ValidateSet("Environments", "Artefacts")]
+        [String] $Expansions
+
     )
 
     if ($PSCmdlet.ParameterSetName -eq 'Account')
@@ -56,6 +61,10 @@ function Get-VstsReleaseDefinition
                 -BoundParameters $PSBoundParameters `
                 -ParameterList 'DefinitionId')
     }
+    
+    if ($Expansions){
+        $additionalInvokeParameters.QueryStringParameters += @{"`$expand" = $Expansions};
+    };
 
     $result = Invoke-VstsEndpoint `
         -Session $Session `


### PR DESCRIPTION
By specifying -Expansions on the Get-VstsReleaseDefinition function, a user can now receive details of artefacts or environments in their releases. 

# What's changed?

https://[account].vsrm.visualstudio.com/DefaultCollection/[project]/_apis/release/definitions?**$expand=Environments**&api-version=3.0-preview.2

Returns objects such as:

![image](https://user-images.githubusercontent.com/773613/38388618-aa4a5250-3913-11e8-8338-ab9d5fe8bb09.png)
